### PR TITLE
Upgrade to dask-ms 0.2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 requirements = [
     "codex-africanus[dask] >= 0.2.0",
-    "dask-ms >= 0.2.0",
+    "dask-ms >= 0.2.3",
     "regions",
     "psutil"
 ]


### PR DESCRIPTION
- [x]  Tests added / passed

  ```bash
  $ py.test --flake8 -v -s .
  ```

  If the flake8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8`
  to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8
  $ autopep8 -r -i .
  $ flake8 .
  ```
