### PR TITLE
Upgrade to dask-ms==0.2.5, codex-africanus==0.2.5

### DIFF
--- a/.travis/py3.docker
+++ b/.travis/py3.docker
@@ -1,12 +1,6 @@
 FROM kernsuite/base:5
 RUN docker-apt-install python3-pip \
-    python-casacore \
-    casacore-dev \
-    python-numpy \
-    python-setuptools \
-    libboost-python-dev \
-    libcfitsio-dev \
-    wcslib-dev
+    python-setuptools
 ADD . /code
 WORKDIR /code
 RUN pip3 install .[testing]

--- a/.travis/py3.docker
+++ b/.travis/py3.docker
@@ -3,5 +3,6 @@ RUN docker-apt-install python3-pip \
     python-setuptools
 ADD . /code
 WORKDIR /code
-RUN pip3 install .[testing]
+RUN python3 -m pip install -U pip setuptools wheels
+RUN python3 -m pip install .[testing]
 RUN py.test --flake8 -s -vvv .

--- a/.travis/py3.docker
+++ b/.travis/py3.docker
@@ -1,6 +1,7 @@
 FROM kernsuite/base:5
 RUN docker-apt-install python3-pip \
-    python-setuptools
+    python-setuptools \
+    git
 ADD . /code
 WORKDIR /code
 RUN python3 -m pip install -U pip setuptools wheel

--- a/.travis/py3.docker
+++ b/.travis/py3.docker
@@ -3,6 +3,6 @@ RUN docker-apt-install python3-pip \
     python-setuptools
 ADD . /code
 WORKDIR /code
-RUN python3 -m pip install -U pip setuptools wheels
+RUN python3 -m pip install -U pip setuptools wheel
 RUN python3 -m pip install .[testing]
 RUN py.test --flake8 -s -vvv .

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,7 @@
 from distutils.core import setup
 
 requirements = [
-    # TODO(sjperkins)
-    # revert to release version once we're happy this works
-    # "codex-africanus[dask]",
-    "codex-africanus[dask]"
-    "@git+https://github.com/ska-sa/codex-africanus.git"
-    "@wsclean-gaussian-conversion-fixes",
-
+    "codex-africanus[dask] >= 0.2.5",
     "dask-ms >= 0.2.5",
     "loguru",
     "regions",

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,14 @@
 from distutils.core import setup
 
 requirements = [
-    "codex-africanus[dask] >= 0.2.2",
-    "dask-ms >= 0.2.3",
+    # TODO(sjperkins)
+    # revert to release version once we're happy this works
+    # "codex-africanus[dask]",
+    "codex-africanus[dask]"
+    "@git+https://github.com/ska-sa/codex-africanus.git"
+    "@wsclean-gaussian-conversion-fixes",
+
+    "dask-ms >= 0.2.5",
     "loguru",
     "regions",
     "psutil"


### PR DESCRIPTION

- [x] Tests added / passed

  ```bash
  $ py.test --flake8 -v -s .
  ```

  If the flake8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8`
  to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8
  $ autopep8 -r -i .
  $ flake8 .
  ```
