### PR TITLE
Encapsulate graph creation in create_predict_graph function for use by external projects

### DIFF
--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -31,7 +31,7 @@ from crystalball.region import load_regions
 from crystalball.wsclean import WSCleanModel, import_from_wsclean
 
 
-def create_parser():
+def create_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser()
     p.add_argument("ms",
                    help="Input .MS file.")
@@ -224,7 +224,7 @@ def predict_cli():
         )
 
 
-def predict(
+def create_predict_graph(
         ms: str,
         sky_model: str = "sky-model.txt",
         output_column: str = "MODEL_DATA",
@@ -237,7 +237,6 @@ def predict(
         num_workers: int = 0,
         memory_fraction: float = 0.1,
         client: Client | None = None,
-        return_delayed: bool = False,
 ):
     pkg_version = version("crystalball")
     log.info(f"Crystalball version {pkg_version}")
@@ -345,9 +344,36 @@ def predict(
         # Add to the list of writes
         writes.append(write)
 
-    # Return the delayed objects for processing elsewhere
-    if return_delayed:
-        return writes
+    return writes
+
+def predict(
+        ms: str,
+        sky_model: str = "sky-model.txt",
+        output_column: str = "MODEL_DATA",
+        field: str | None = None,
+        row_chunks: int = 0,
+        model_chunks: int = 0,
+        within: str | None = None,
+        points_only: bool = False,
+        num_sources: int = 0,
+        num_workers: int = 0,
+        memory_fraction: float = 0.1,
+        client: Client | None = None,
+):
+    
+    writes = create_predict_graph(
+        sky_model=sky_model,
+        output_column=output_column,
+        field=field,
+        row_chunks=row_chunks,
+        model_chunks=model_chunks,
+        witin=within,
+        points_only=points_only,
+        num_sources=num_sources,
+        num_worker=num_workers,
+        memory_fraction=memory_fraction,
+        client=client
+    )
 
     tick = time()
     with ExitStack() as stack:

--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -362,6 +362,7 @@ def predict(
 ):
     
     writes = create_predict_graph(
+         ms=ms,
         sky_model=sky_model,
         output_column=output_column,
         field=field,

--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -370,7 +370,7 @@ def predict(
         within=within,
         points_only=points_only,
         num_sources=num_sources,
-        num_worker=num_workers,
+        num_workers=num_workers,
         memory_fraction=memory_fraction,
         client=client
     )

--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -345,6 +345,10 @@ def predict(
         # Add to the list of writes
         writes.append(write)
 
+    # Return the delayed objects for processing elsewhere
+    if return_delayed:
+        return writes
+
     tick = time()
     with ExitStack() as stack:
         if sys.stdout.isatty():
@@ -355,8 +359,6 @@ def predict(
             stack.enter_context(EstimatingProgressBar(minimum=2 * 60, dt=5))
 
         # Submit all graph computations in parallel
-        if return_delayed:
-            return writes
         if client is not None:
             future_list = client.compute(writes)
             progress(future_list)

--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -236,7 +236,8 @@ def predict(
         num_sources: int = 0,
         num_workers: int = 0,
         memory_fraction: float = 0.1,
-        client: Client | None = None
+        client: Client | None = None,
+        return_delayed: bool = False,
 ):
     pkg_version = version("crystalball")
     log.info(f"Crystalball version {pkg_version}")
@@ -354,6 +355,8 @@ def predict(
             stack.enter_context(EstimatingProgressBar(minimum=2 * 60, dt=5))
 
         # Submit all graph computations in parallel
+        if return_delayed:
+            return writes
         if client is not None:
             future_list = client.compute(writes)
             progress(future_list)

--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -367,7 +367,7 @@ def predict(
         field=field,
         row_chunks=row_chunks,
         model_chunks=model_chunks,
-        witin=within,
+        within=within,
         points_only=points_only,
         num_sources=num_sources,
         num_worker=num_workers,


### PR DESCRIPTION
This PR adds an option to return the delayed objects themselves without running the `Client.submit` method to collect the futures. 

